### PR TITLE
agnoster適用できるように

### DIFF
--- a/settings/.config.fish
+++ b/settings/.config.fish
@@ -3,6 +3,7 @@
 if status --is-interactive
   # theme
   omf theme agnoster
+  fisher omf/theme-agnoster
 
   # vi の挙動に
   fish_vi_key_bindings


### PR DESCRIPTION
settings/.config.fish内のagnosterについての記述を変更
omfでagnosterを適用するようにした